### PR TITLE
Change requirements to 'Django>=1.11,<3.3'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from djangocms_column import __version__
 
 INSTALL_REQUIRES = [
     'django-cms>=3.4.5',
-    'Django>=1.11,<=3.2',
+    'Django>=1.11,<3.3',
     'six>=1.9.0',
 ]
 


### PR DESCRIPTION
We had <=3.2, which doesn’t work for >=3.2.1.
<3.3 works for 3.2.*.