### PR TITLE
fix: remove usage of ugettext_lazy from the code

### DIFF
--- a/djangocms_column/cms_plugins.py
+++ b/djangocms_column/cms_plugins.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cms.models import CMSPlugin
 from cms.plugin_base import CMSPluginBase

--- a/djangocms_column/forms.py
+++ b/djangocms_column/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import WIDTH_CHOICES, MultiColumns
 

--- a/djangocms_column/models.py
+++ b/djangocms_column/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cms.models import CMSPlugin
 


### PR DESCRIPTION
Fixes the following warnings:

RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().