### PR TITLE
Update cms_plugins.py - now using cms.api to add columns

### DIFF
--- a/djangocms_column/cms_plugins.py
+++ b/djangocms_column/cms_plugins.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from cms.models import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-
+from cms import api
 from .forms import MultiColumnForm
 from .models import Column, MultiColumns
 
@@ -22,13 +22,12 @@ class MultiColumnPlugin(CMSPluginBase):
             request, obj, form, change
         )
         for _x in range(int(form.cleaned_data['create'])):
-            col = Column(
-                parent=obj,
+            col = api.add_plugin(
                 placeholder=obj.placeholder,
+                plugin_type=ColumnPlugin.__name__,
                 language=obj.language,
+                target=obj,
                 width=form.cleaned_data['create_width'],
-                position=CMSPlugin.objects.filter(parent=obj).count(),
-                plugin_type=ColumnPlugin.__name__
             )
             col.save()
         return response


### PR DESCRIPTION
Using cms.api to make the plugin compatible with django-cms v4 as well. This patch also works for django-cms v3.

## Description

Changed cms_plugins.py `save_model` method to make the plugin work with django-cms v3 and v4 by using the `cms.api` for adding columns.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
